### PR TITLE
saas_portal: fix request.get fail for unverified ssl

### DIFF
--- a/saas_portal/models/wizard.py
+++ b/saas_portal/models/wizard.py
@@ -60,7 +60,7 @@ class SaasConfig(models.TransientModel):
             client_id=self.database_id.client_id,
             state=state,
         )[0]
-        res = requests.get(url)
+        res = requests.get(url, verify=(self.server_id.request_scheme == 'https' and self.server_id.verify_ssl))
         obj.write({'description': res.text})
         return {
             'type': 'ir.actions.act_window',

--- a/saas_portal/views/saas_portal.xml
+++ b/saas_portal/views/saas_portal.xml
@@ -150,6 +150,7 @@
                             <field name="client_id"/>
                             <field name="active"/>
                             <field name="request_scheme"/>
+			    <field name="verify_ssl" attrs="{'invisible': [('request_scheme', '!=', 'https')]}"/>
                             <field name="request_port"/>
                         </group>
                     </group>


### PR DESCRIPTION
Request.get fails when using a self-signed certificate
to prevent this we are adding verify_ssl field to saas_portal.server
when unchecked it prevents the server's ssl from being verified