### PR TITLE
saas_portal: Simple Error handling for request

### DIFF
--- a/saas_portal/models/saas_portal.py
+++ b/saas_portal/models/saas_portal.py
@@ -95,6 +95,12 @@ class SaasPortalServer(models.Model):
         }
         url = self._request_server(path='/saas_server/sync_server', state=state, client_id=self.client_id)[0]
         res = requests.get(url)
+	if res.ok != True:
+            msg = """Status Code - %s 
+            Reason - %s
+            URL - %s
+            """ % (res.status_code, res.reason, res.url)
+            raise Warning(msg)
         data = simplejson.loads(res.text)
         for r in data:
             r['server_id'] = self.id

--- a/saas_portal/models/saas_portal.py
+++ b/saas_portal/models/saas_portal.py
@@ -96,12 +96,12 @@ class SaasPortalServer(models.Model):
         }
         url = self._request_server(path='/saas_server/sync_server', state=state, client_id=self.client_id)[0]
         res = requests.get(url, verify=(self.request_scheme == 'https' and self.verify_ssl))
-	if res.ok != True:
-	    msg = """Status Code - %s 
-		Reason - %s
-		URL - %s
-		""" % (res.status_code, res.reason, res.url)
-	    raise Warning(msg)
+    	if res.ok != True:
+    	    msg = """Status Code - %s 
+    		Reason - %s
+    		URL - %s
+    		""" % (res.status_code, res.reason, res.url)
+    	    raise Warning(msg)
         data = simplejson.loads(res.text)
         for r in data:
             r['server_id'] = self.id

--- a/saas_portal/models/wizard.py
+++ b/saas_portal/models/wizard.py
@@ -61,13 +61,13 @@ class SaasConfig(models.TransientModel):
             state=state,
         )[0]
         res = requests.get(url, verify=(self.server_id.request_scheme == 'https' and self.server_id.verify_ssl))
-	if res.ok != True:
-	    msg = """Status Code - %s 
-	        Reason - %s
-	        URL - %s
-	        """ % (res.status_code, res.reason, res.url)
-	    raise Warning(msg)
-	obj.write({'description': res.text})
+    	if res.ok != True:
+    	    msg = """Status Code - %s 
+    	        Reason - %s
+    	        URL - %s
+    	        """ % (res.status_code, res.reason, res.url)
+    	    raise Warning(msg)
+    	obj.write({'description': res.text})
         return {
             'type': 'ir.actions.act_window',
             'view_type': 'form',

--- a/saas_portal/models/wizard.py
+++ b/saas_portal/models/wizard.py
@@ -61,6 +61,12 @@ class SaasConfig(models.TransientModel):
             state=state,
         )[0]
         res = requests.get(url)
+	if res.ok != True:
+            msg = """Status Code - %s 
+            Reason - %s
+            URL - %s
+            """ % (res.status_code, res.reason, res.url)
+            raise Warning(msg)
         obj.write({'description': res.text})
         return {
             'type': 'ir.actions.act_window',


### PR DESCRIPTION
Block to enable simple error handling for calls to request.get

Helps present helpful request error message that can easily be acted on...
For instance saas_portal/models/saas_portal.py line 98 directly sends the result of the request to 
simplejson.loads which spits out errors msgs that can have you chasing your tail for awhile.

Anywaz what are thoughts on this