### PR TITLE
[ADD]saas_portal_more_like_this:

### DIFF
--- a/saas_portal_more_like_this/README.rst
+++ b/saas_portal_more_like_this/README.rst
@@ -1,0 +1,18 @@
+SaaS Portal More Like This
+==========================
+
+Module allows you to provision a client instance that is an exact replica of 
+another existing client.
+
+The reason for this being that it is not uncommon for clients instance to evolve
+far beyond the template on which they are based. And so this allows you to 
+provision an identical instance in seconds rather than have to re-appply all your
+changes to the template. 
+
+This module is very useful in cases in which you wish to provide a training 
+environment for a client based on the exact copy of their live instance
+
+Notes
+-----
+
+* please not that this copies over the entire DB and not just configuration and so should not be used to provision new client... use templates instead as that is what they are for

--- a/saas_portal_more_like_this/__init__.py
+++ b/saas_portal_more_like_this/__init__.py
@@ -1,0 +1,1 @@
+import models

--- a/saas_portal_more_like_this/__openerp__.py
+++ b/saas_portal_more_like_this/__openerp__.py
@@ -1,0 +1,12 @@
+{
+    'name': 'SaaS Portal More Like This',
+    'version': '1.0.0',
+    'author': 'Salton Massally',
+    'category': 'SaaS',
+    'website': 'http://idtlabs.sl',
+    'depends': ['saas_portal'],
+    'data': [
+        'views/wizard.xml',
+        ],
+    'installable': True,
+}

--- a/saas_portal_more_like_this/models/__init__.py
+++ b/saas_portal_more_like_this/models/__init__.py
@@ -1,0 +1,2 @@
+import saas_portal
+import wizard

--- a/saas_portal_more_like_this/models/saas_portal.py
+++ b/saas_portal_more_like_this/models/saas_portal.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+import openerp
+from openerp import models, fields, api, SUPERUSER_ID, exceptions
+from openerp.addons.saas_utils import connector, database
+from openerp import http
+from openerp.tools import config, scan_languages
+from openerp.tools.translate import _
+from openerp.addons.base.res.res_partner import _tz_get
+import time
+from datetime import datetime, timedelta
+from openerp.tools import DEFAULT_SERVER_DATETIME_FORMAT
+from oauthlib import common as oauthlib_common
+import urllib2
+import simplejson
+import werkzeug
+import requests
+import random
+
+import logging
+_logger = logging.getLogger(__name__)
+
+class SaasPortalClient(models.Model):
+    _inherit = 'saas_portal.client'
+    
+    @api.one
+    def duplicate_database(self, dbname=None, partner_id=None, expiration=None):
+        server = self.server_id
+        if not server:
+            server = self.env['saas_portal.server'].get_saas_server()
+
+        server.action_sync_server()
+
+        vals = {'name': dbname,
+                'server_id': server.id,
+                'plan_id': self.plan_id.id,
+                'partner_id': partner_id or self.partner_id.id,
+                }
+        if expiration:
+            now = datetime.now()
+            delta = timedelta(hours=expiration)
+            vals['expiration_datetime'] = (now + delta).strftime(DEFAULT_SERVER_DATETIME_FORMAT)
+
+        client = self.env['saas_portal.client'].create(vals)
+        client_id = client.client_id
+
+        scheme = server.request_scheme
+        port = server.request_port
+        state = {
+            'd': client.name,
+            'e': client.expiration_datetime,
+            'r': '%s://%s:%s/web' % (scheme, port, client.name),
+        }
+        state.update({'db_template': self.name})
+        scope = ['userinfo', 'force_login', 'trial', 'skiptheuse']
+        url = server._request(path='/saas_server/new_database',
+                              scheme=scheme,
+                              port=port,
+                              state=state,
+                              client_id=client_id,
+                              scope=scope,)[0]
+        return url

--- a/saas_portal_more_like_this/models/wizard.py
+++ b/saas_portal_more_like_this/models/wizard.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+import requests
+import werkzeug
+import datetime
+import simplejson
+
+import openerp
+from openerp.addons.saas_utils import connector, database
+from openerp.addons.web.http import request
+from openerp.tools import config
+from openerp import models, fields, api, SUPERUSER_ID
+from openerp import http
+
+
+class SaasPortalDuplicateClient(models.TransientModel):
+    _name = 'saas_portal.duplicate_client'
+
+    def _default_client_id(self):
+        return self._context.get('active_id')
+
+    def _default_partner(self):
+        client_id = self._default_client_id()
+        if client_id:
+            client = self.env['saas_portal.client'].browse(client_id)
+            return client.partner_id
+        return ''
+    
+    def _default_expiration(self):
+        client_id = self._default_client_id()
+        if client_id:
+            client = self.env['saas_portal.client'].browse(client_id)
+            return client.plan_id.expiration
+        return ''
+
+    name = fields.Char('Database Name', required=True)
+    client_id = fields.Many2one('saas_portal.client', string='Base Client', readonly=True, default=_default_client_id)
+    expiration = fields.Integer('Expiration', default=_default_expiration)
+    partner_id = fields.Many2one('res.partner', string='Partner', default=_default_partner)
+
+    @api.multi
+    def apply(self):
+        wizard = self[0]
+        url = wizard.client_id.duplicate_database(dbname=wizard.name, partner_id=wizard.partner_id.id, expiration=None)
+        return {
+            'type': 'ir.actions.act_url',
+            'target': 'new',
+            'name': 'Duplicate Client',
+            'url': url
+        }

--- a/saas_portal_more_like_this/views/wizard.xml
+++ b/saas_portal_more_like_this/views/wizard.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="saas_portal_duplicate_client_view_form" model="ir.ui.view">
+            <field name="name">saas_portal.duplicate_client.form</field>
+            <field name="model">saas_portal.duplicate_client</field>
+            <field name="arch" type="xml">
+                <form string="Duplicate client">
+                     <group>
+                        <field name="name"/>
+                        <field name="client_id"/>
+                        <field name="partner_id" class="oe_inline"/>
+                        <field name="expiration" />
+                     </group>
+                     <footer>
+                        <button name="apply" string="Duplicate" type="object" class="oe_highlight"/>
+                        or
+                        <button string="Close" class="oe_link" special="cancel"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+        
+        <act_window
+            id="action_duplicate_client"
+            name="Create More Like This"
+            res_model="saas_portal.duplicate_client"
+            src_model="saas_portal.client"
+            target="new"
+            view_mode="form"
+            view_type="form"
+            />
+    </data>
+</openerp>


### PR DESCRIPTION
Module allows you to provision a client instance that is an exact replica of
another existing client.

The reason for this being that it is not uncommon for clients instance to evolve
far beyond the template on which they are based. And so this allows you to
provision an identical instance in seconds rather than have to re-appply all your
changes to one provisioned off the template.

This module is very useful in cases in which you wish to provide a training
environment for a client based on the exact copy of their live instance