### PR TITLE
[IMP] Persist UI changes made to not_admin_tenant_rule

### DIFF
--- a/saas_client/security/rules.xml
+++ b/saas_client/security/rules.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
-    <data>
+    <data  noupdate="1">
     	
-		<record id="not_admin_tenant_rule" model="ir.rule">
+	<record id="not_admin_tenant_rule" model="ir.rule">
 	        <field name="name">Only admin can edit admin</field>
 	        <field name="model_id" ref="base.model_res_users"/>
 			<field name="global" eval="1" />


### PR DESCRIPTION
Reading the commit on the file I understand why you want the admin user to be readonly;
however people's opinion on this is going to differ. For example I think most users would
frown at seeing someone external to their company listed among the user list....

TO ensure that people can implement whatever they think works for them by editing the rules via the UI
I think adding a noupdate is  necessary