### PR TITLE
[IMP] saas_portal - duplicate clients

### DIFF
--- a/saas_portal/models/saas_portal.py
+++ b/saas_portal/models/saas_portal.py
@@ -471,7 +471,8 @@ class SaasPortalClient(models.Model):
             'e': client.expiration_datetime,
             'r': '%s://%s:%s/web' % (scheme, port, client.name),
         }
-        state.update({'db_template': self.name})
+        sstate.update({'db_template': self.name,
+                      'disable_mail_server' : True})
         scope = ['userinfo', 'force_login', 'trial', 'skiptheuse']
         url = server._request(path='/saas_server/new_database',
                               scheme=scheme,

--- a/saas_portal/models/saas_portal.py
+++ b/saas_portal/models/saas_portal.py
@@ -442,3 +442,41 @@ class SaasPortalClient(models.Model):
             #    user_model.unlink(cr, uid, user_ids)
             #openerp.service.db.exp_drop(obj.name)
         return super(SaasPortalClient, self).unlink(cr, uid, ids, context)
+
+    @api.one
+    def duplicate_database(self, dbname=None, partner_id=None, expiration=None):
+        server = self.server_id
+        if not server:
+            server = self.env['saas_portal.server'].get_saas_server()
+
+        server.action_sync_server()
+
+        vals = {'name': dbname,
+                'server_id': server.id,
+                'plan_id': self.plan_id.id,
+                'partner_id': partner_id or self.partner_id.id,
+                }
+        if expiration:
+            now = datetime.now()
+            delta = timedelta(hours=expiration)
+            vals['expiration_datetime'] = (now + delta).strftime(DEFAULT_SERVER_DATETIME_FORMAT)
+
+        client = self.env['saas_portal.client'].create(vals)
+        client_id = client.client_id
+
+        scheme = server.request_scheme
+        port = server.request_port
+        state = {
+            'd': client.name,
+            'e': client.expiration_datetime,
+            'r': '%s://%s:%s/web' % (scheme, port, client.name),
+        }
+        state.update({'db_template': self.name})
+        scope = ['userinfo', 'force_login', 'trial', 'skiptheuse']
+        url = server._request(path='/saas_server/new_database',
+                              scheme=scheme,
+                              port=port,
+                              state=state,
+                              client_id=client_id,
+                              scope=scope,)[0]
+        return url

--- a/saas_portal/models/wizard.py
+++ b/saas_portal/models/wizard.py
@@ -124,3 +124,40 @@ class SaasPortalCreateClient(models.TransientModel):
             'name': 'Create Client',
             'url': url
         }
+
+
+class SaasPortalDuplicateClient(models.TransientModel):
+    _name = 'saas_portal.duplicate_client'
+
+    def _default_client_id(self):
+        return self._context.get('active_id')
+
+    def _default_partner(self):
+        client_id = self._default_client_id()
+        if client_id:
+            client = self.env['saas_portal.client'].browse(client_id)
+            return client.partner_id
+        return ''
+    
+    def _default_expiration(self):
+        client_id = self._default_client_id()
+        if client_id:
+            client = self.env['saas_portal.client'].browse(client_id)
+            return client.plan_id.expiration
+        return ''
+
+    name = fields.Char('Database Name', required=True)
+    client_id = fields.Many2one('saas_portal.client', string='Base Client', readonly=True, default=_default_client_id)
+    expiration = fields.Integer('Expiration', default=_default_expiration)
+    partner_id = fields.Many2one('res.partner', string='Partner', default=_default_partner)
+
+    @api.multi
+    def apply(self):
+        wizard = self[0]
+        url = wizard.client_id.duplicate_database(dbname=wizard.name, partner_id=wizard.partner_id.id, expiration=None)
+        return {
+            'type': 'ir.actions.act_url',
+            'target': 'new',
+            'name': 'Duplicate Client',
+            'url': url
+        }

--- a/saas_portal/views/wizard.xml
+++ b/saas_portal/views/wizard.xml
@@ -29,5 +29,36 @@
             <field name="view_id" ref="saas_portal_create_client_view_form"/>
             <field name="target">new</field>
         </record>
+        
+        
+        <record id="saas_portal_duplicate_client_view_form" model="ir.ui.view">
+            <field name="name">saas_portal.duplicate_client.form</field>
+            <field name="model">saas_portal.duplicate_client</field>
+            <field name="arch" type="xml">
+                <form string="Duplicate client">
+                     <group>
+                        <field name="name"/>
+                        <field name="client_id"/>
+                        <field name="partner_id" class="oe_inline"/>
+                        <field name="expiration" />
+                     </group>
+                     <footer>
+                        <button name="apply" string="Duplicate" type="object" class="oe_highlight"/>
+                        or
+                        <button string="Close" class="oe_link" special="cancel"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+        
+        <act_window
+            id="action_duplicate_client"
+            name="Create More Like This"
+            res_model="saas_portal.duplicate_client"
+            src_model="saas_portal.client"
+            target="new"
+            view_mode="form"
+            view_type="form"
+            />
     </data>
 </openerp>

--- a/saas_server/controllers/main.py
+++ b/saas_server/controllers/main.py
@@ -28,6 +28,7 @@ class SaasServer(http.Controller):
         new_db = state.get('d')
         expiration_db = state.get('e')
         template_db = state.get('db_template')
+        disable_mail_server = state.get('disable_mail_server', False)
         demo = state.get('demo')
         lang = state.get('lang', 'en_US')
         tz = state.get('tz')
@@ -51,6 +52,8 @@ class SaasServer(http.Controller):
         client = request.env['saas_server.client'].sudo().create(client_data)
         client.create_database(template_db, demo, lang)
         client.install_addons(addons=addons, is_template_db=is_template_db)
+        if disable_mail_server:
+            client.disable_mail_servers()
         client.update_registry()
         client.prepare_database(
             tz=tz,

--- a/saas_server/models/saas_server.py
+++ b/saas_server/models/saas_server.py
@@ -71,6 +71,20 @@ class SaasServerClient(models.Model):
         with self.registry()[0].cursor() as cr:
             env = api.Environment(cr, SUPERUSER_ID, self._context)
             self._install_addons(env, addons)
+    @api.one
+    def disable_mail_servers(self):
+        '''
+        disables mailserver on db to stop it from sending and receiving mails
+        '''
+        # let's disable incoming mail servers
+        incoming_mail_servers = self.env['fetchmail.server'].search([])
+        if len(incoming_mail_servers):
+            incoming_mail_servers.write({'active': False})
+            
+        # let's disable outgoing mailservers too
+        outgoing_mail_servers = self.env['ir.mail_server'].search([])
+        if len(outgoing_mail_servers):
+            outgoing_mail_servers.write({'active': False})
 
     @api.one
     def _install_addons(self, client_env, addons):


### PR DESCRIPTION
allows you to provision a client instance that is an exact replica of
another existing client.

The reason for this being that it is not uncommon for clients instance to evolve
far beyond the template on which they are based. And so this allows you to
provision an identical instance in seconds rather than have to re-appply all your
changes to one provisioned off the template.

very useful in cases in which you wish to provide a training
environment for a client based on the exact copy of their live instance