### PR TITLE
template database handling

### DIFF
--- a/saas_portal/models/saas_portal.py
+++ b/saas_portal/models/saas_portal.py
@@ -306,7 +306,9 @@ URL - %s
 
     @api.multi
     def delete_template(self):
-        return self[0].template_id.delete_database()
+        res = self[0].template_id.delete_database()
+        self.unlink()
+        return res
 
 
 class OauthApplication(models.Model):

--- a/saas_portal/models/saas_portal.py
+++ b/saas_portal/models/saas_portal.py
@@ -307,7 +307,6 @@ URL - %s
     @api.multi
     def delete_template(self):
         res = self[0].template_id.delete_database()
-        self.unlink()
         return res
 
 

--- a/saas_portal/views/saas_portal.xml
+++ b/saas_portal/views/saas_portal.xml
@@ -348,6 +348,41 @@
             <field name="model">saas.config</field>
             <field name="value_unpickle" eval="'ir.actions.act_window,'+str(action_updb)"/>
         </record>
+        
+         <!-- Templates -->
+        <record id="view_databases_tree" model="ir.ui.view">
+            <field name="name">saas_portal.databases.tree</field>
+            <field name="model">saas_portal.database</field>
+            <field name="arch" type="xml">
+                <tree string="Plans">
+                     <field name="name" />
+                     <field name="state" />
+                     <field name="client_id" />
+                </tree>
+            </field>
+        </record>
+        
+        <record id="view_databases_filter" model="ir.ui.view">
+            <field name="name">saas_portal.database.select</field>
+            <field name="model">saas_portal.database</field>
+            <field name="arch" type="xml">
+                <search string="Search Databases">
+                    <field name="name" string="Database Name"/>
+                    <filter string="Templates" name="template" domain="[('state', '=','template')]"/>
+                </search>
+            </field>
+        </record>
+        
+        <record id="action_templates" model="ir.actions.act_window">
+            <field name="name">Templates</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">saas_portal.database</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="context">{'search_default_template': 1}</field>
+        </record>
+
+        <menuitem action="action_templates" id="menu_templates" parent="menu_saas" sequence="40" groups="base.group_no_one"/>
 
     </data>
 </openerp>


### PR DESCRIPTION
*Add a menuitem via which technical users can view template databases
*When "Delete Template" is clicked there is no reason to still keep the saas_portal.database