### PR TITLE
saas_client security

### DIFF
--- a/saas_client/__openerp__.py
+++ b/saas_client/__openerp__.py
@@ -8,6 +8,7 @@
     'data': [
         'views/saas_client.xml',
         'security/rules.xml',
+        'security/groups.xml',
         'data/ir_cron.xml',
         'data/auth_oauth_data.xml',
     ],

--- a/saas_client/models/res_user.py
+++ b/saas_client/models/res_user.py
@@ -18,11 +18,8 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-import openerp
 from openerp import models, fields, api, SUPERUSER_ID as SI, exceptions
-from openerp.tools import config
 from openerp.tools.translate import _
-from openerp.addons.saas_utils import connector
 
 
 class ResUsers(models.Model):
@@ -41,37 +38,3 @@ class ResUsers(models.Model):
             if cur_users >= max_users:
                 raise exceptions.Warning(_('Maximimum allowed users is %(max_users)s, while you already have %(cur_users)s') % {'max_users':max_users, 'cur_users': cur_users})
         return super(ResUsers, self).create(vals)
-
-
-    available_addons_ids = fields.Many2many(compute='_compute_addons',
-                                            comodel_name='ir.module.module',
-                                            string='Available Addons')
-
-    @api.one
-    def _compute_addons(self):
-        addon_ids = []
-        add_names = []
-        login = self.login
-        db = config.get('db_master')
-        registry = openerp.modules.registry.RegistryManager.get(db)
-        with registry.cursor() as cr:
-            ru = registry['res.users']
-            user_ids = ru.search(cr, SI, [('login', '=', login)])
-            if user_ids:
-                user = ru.browse(cr, SI, user_ids[0])
-                add_names = [x.name for x in user.plan_id.optional_addons_ids]
-        if add_names:
-            imm = self.env['ir.module.module']
-            addons = imm.search([('name', 'in', add_names)])
-            dependencies = []
-            for addon in addons:
-                dependencies += self._get_dependencies(addon)
-            addon_ids = list(set([x.id for x in addons] + dependencies))
-        self.available_addons_ids = addon_ids
-
-    def _get_dependencies(self, addon):
-        dependencies = []
-        for dep in addon.dependencies_id:
-            dependencies.append(dep.depend_id.id)
-            dependencies += self._get_dependencies(dep.depend_id)
-        return dependencies

--- a/saas_client/security/groups.xml
+++ b/saas_client/security/groups.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="group_no_client" model="res.groups">
+            <field name="name">Non-client</field>
+            <field name="users" eval="[(4, ref('base.user_root'))]"/>
+            <field name="comment">Special group for superuser. Should not be used for client users</field>
+        </record>
+
+    </data>
+</openerp>

--- a/saas_client/security/groups.xml
+++ b/saas_client/security/groups.xml
@@ -2,8 +2,8 @@
 <openerp>
     <data>
 
-        <record id="group_no_client" model="res.groups">
-            <field name="name">Non-client</field>
+        <record id="group_saas_support" model="res.groups">
+            <field name="name">SaaS Support</field>
             <field name="users" eval="[(4, ref('base.user_root'))]"/>
             <field name="comment">Special group for superuser. Should not be used for client users</field>
         </record>

--- a/saas_client/security/rules.xml
+++ b/saas_client/security/rules.xml
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data  noupdate="1">
-    	
-	<record id="not_admin_tenant_rule" model="ir.rule">
-	        <field name="name">Only admin can edit admin</field>
-	        <field name="model_id" ref="base.model_res_users"/>
-			<field name="global" eval="1" />
-	        <field name="domain_force">[('id', '!=', 1)]</field>
-            <field name="perm_read" eval="False" />
-	    </record>
-
 		<record id="slave_module_domain_rule" model="ir.rule">
             <field name="name">Addons Domain</field>
             <field name="model_id" ref="base.model_ir_module_module"/>

--- a/saas_client/security/rules.xml
+++ b/saas_client/security/rules.xml
@@ -1,15 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data  noupdate="1">
-		<record id="slave_module_domain_rule" model="ir.rule">
-            <field name="name">Addons Domain</field>
-            <field name="model_id" ref="base.model_ir_module_module"/>
-            <field name="domain_force">[('id', 'in', [x.id for x in user.available_addons_ids])]</field>
-            <field name="perm_create" eval="True"/>
-			<field name="perm_read" eval="True"/>
-            <field name="perm_unlink" eval="True"/>
-            <field name="perm_write" eval="True"/>
-            <field name="active" eval="False"/> <!--FIXME available_addons_ids doesn't work-->
-        </record>
     </data>
 </openerp>

--- a/saas_portal/models/saas_portal.py
+++ b/saas_portal/models/saas_portal.py
@@ -163,15 +163,6 @@ class SaasPortalPlan(models.Model):
     state = fields.Selection([('draft', 'Draft'), ('confirmed', 'Confirmed')],
                              'State', compute='_get_state', store=True)
     expiration = fields.Integer('Expiration (hours)', help='time to delete database. Use for demo')
-    required_addons_ids = fields.Many2many('ir.module.module',
-                                           relation='plan_required_addons_rel',
-                                           column1='plan_id', column2='module_id',
-                                           string='Required Addons')
-    optional_addons_ids = fields.Many2many('ir.module.module',
-                                           relation='plan_optional_addons_rel',
-                                           column1='plan_id', column2='module_id',
-                                           string='Optional Addons')
-
     _order = 'sequence'
 
     dbname_template = fields.Char('DB Names', help='Template for db name. Use %i for numbering. Ignore if you use manually created db names', placeholder='crm-%i.odoo.com')

--- a/saas_portal/models/wizard.py
+++ b/saas_portal/models/wizard.py
@@ -50,7 +50,7 @@ class SaasConfig(models.TransientModel):
             'install_addons': (obj.install_addons or '').split(','),
             'uninstall_addons': (obj.uninstall_addons or '').split(','),
             'fixes': [[x.model, x.method] for x in obj.fix_ids],
-            'params': [[x.key, x.value] for x in obj.param_ids],
+            'params': [{'key': x.key, 'value': x.value, 'hidden': x.hidden} for x in obj.param_ids],
         }
         state = {
             'data': payload,
@@ -96,6 +96,7 @@ class SaasConfigParam(models.TransientModel):
     key = fields.Selection(selection=_get_keys, string='Key', required=1, size=64)
     value = fields.Char('Value', required=1, size=64)
     config_id = fields.Many2one('saas.config', 'Config')
+    hidden = fields.Boolean('Hidden parameter', default=True)
 
 class SaasPortalCreateClient(models.TransientModel):
     _name = 'saas_portal.create_client'

--- a/saas_server/models/saas_server.py
+++ b/saas_server/models/saas_server.py
@@ -259,9 +259,11 @@ class SaasServerClient(models.Model):
 
         # 5. update parameters
         params = post.get('params', [])
-        for key, value in params:
-            client_env['ir.config_parameter'].set_param(key, value)
-
+        for obj in params:
+            groups = []
+            if obj.get('hidden'):
+                groups = ['saas_client.group_no_client']
+            client_env['ir.config_parameter'].set_param(obj['key'], obj['value'], groups=groups)
         return 'OK'
 
     @api.model

--- a/saas_server/models/saas_server.py
+++ b/saas_server/models/saas_server.py
@@ -262,7 +262,7 @@ class SaasServerClient(models.Model):
         for obj in params:
             groups = []
             if obj.get('hidden'):
-                groups = ['saas_client.group_no_client']
+                groups = ['saas_client.group_saas_support']
             client_env['ir.config_parameter'].set_param(obj['key'], obj['value'], groups=groups)
         return 'OK'
 


### PR DESCRIPTION
This PR is an implementation of the idea of flexible configuration for Saas Client database (see #51 and new section "Client database customization" at root Readme file).

The idea is to have separate addons for customizing security rights on Client Databases. It makes customization flexible from one side, and easier to maintain such addons from other side.

[Maximum allowed users feature](https://github.com/yelizariev/odoo-saas-tools/blob/e0ca4d780ad44cb8203ded584073b3949d0cdee9/saas_client/models/res_user.py#L32-L40) could be moved to a separate addon too. For now, I've removed code that seems doesn't work after a lot of update and refactoring we made.

cc @kaerdsar , @dhbahr , @tarzan0820 

