### PR TITLE
[ADD] saas_portal, saas_server: parameter to set owner_user password …

### DIFF
--- a/saas_portal/models/saas_portal.py
+++ b/saas_portal/models/saas_portal.py
@@ -199,7 +199,7 @@ class SaasPortalPlan(models.Model):
         return self._create_new_database(**kwargs)
 
     @api.multi
-    def _create_new_database(self, dbname=None, client_id=None, partner_id=None, user_id=None, notify_user=False, trial=False, support_team_id=None, async=None):
+    def _create_new_database(self, dbname=None, client_id=None, partner_id=None, user_id=None, notify_user=False, trial=False, support_team_id=None, async=None, owner_password=None):
         self.ensure_one()
 
         server = self.server_id
@@ -261,6 +261,7 @@ class SaasPortalPlan(models.Model):
         owner_user_data = {
             'user_id': owner_user.id,
             'login': owner_user.login,
+            'password': owner_password,
             'name': owner_user.name,
             'email': owner_user.email,
         }

--- a/saas_server/models/saas_server.py
+++ b/saas_server/models/saas_server.py
@@ -171,6 +171,7 @@ class SaasServerClient(models.Model):
                 user = client_env['res.users'].browse(SUPERUSER_ID)
             user.write({
                 'login': owner_user['login'],
+                'password': owner_user['password'],
                 'name': owner_user['name'],
                 'email': owner_user['email'],
                 'oauth_provider_id': oauth_provider.id,


### PR DESCRIPTION
…in client database. If you pass this parameter to saas_portal.plan._create_new_database then clients can login using this password. Otherwise they can login only through portal